### PR TITLE
Templates for platform and components

### DIFF
--- a/_data/components.yml
+++ b/_data/components.yml
@@ -1,0 +1,53 @@
+- name: LED
+  image: grove/led.svg
+  image-alt: Grove LED
+  documentation: https://zorg-gpio.readthedocs.org/en/latest/led/
+  examples: https://zorg-gpio.readthedocs.org/en/latest/led/#examples
+
+- name: Buzzer
+  image: grove/buzzer.svg
+  image-alt: Grove buzzer
+  documentation: https://zorg-gpio.readthedocs.org/en/latest/button/
+  examples: https://zorg-gpio.readthedocs.org/en/latest/button/#examples
+
+- name: Button
+  image: grove/button.svg
+  image-alt: Grove buzzer
+  documentation: https://zorg-gpio.readthedocs.org/en/latest/button/
+  examples: https://zorg-gpio.readthedocs.org/en/latest/button/#examples
+
+- name: Temperature sensor
+  image: grove/temperature_sensor.svg
+  image-alt: Grove temperature sensor
+  documentation: https://zorg-gpio.readthedocs.org/en/latest/temperature_sensor/
+
+- name: Servo
+  image: grove/servo.svg
+  image-alt: Grove servo
+  documentation: https://zorg-gpio.readthedocs.org/en/latest/servo/
+
+- name: LCD with RGB backlight
+  image: grove/lcd.svg
+  image-alt: Grove LCD with RGB backlight
+  documentation: https://zorg-grove.readthedocs.org/en/latest/docs/LCD.html
+
+- name: Smart relay
+  image: grove/relay.svg
+  image-alt: Grove smart relay
+  documentation: https://zorg-gpio.readthedocs.org/en/latest/relay/
+
+- name: Light sensor
+  image: grove/light_sensor.svg
+  image-alt: Grove light sensor
+
+- name: Rotary angle sensor
+  image: grove/rotary_angle_sensor.svg
+  image-alt: Grove rotary angle sensor
+
+- name: Sound sensor
+  image: grove/sound_sensor.svg
+  image-alt: Grove sound sensor
+
+- name: Touch sensor
+  image: grove/touch_sensor.svg
+  image-alt: Grove touch sensor

--- a/_data/platforms.yml
+++ b/_data/platforms.yml
@@ -1,0 +1,11 @@
+- name: Intel Edison
+  image: edison.svg
+  getting-started: /platforms/edison/install/
+  documentation: https://zorg-edison.readthedocs.org/
+
+- name: Raspberry PI
+  image: raspberry_pi.svg
+
+- name: Arduino Firmata
+  image: arduino_uno.svg
+  examples: https://github.com/zorg-framework/zorg-firmata/tree/master/examples

--- a/_includes/component-card.html
+++ b/_includes/component-card.html
@@ -1,0 +1,26 @@
+<div class="card">
+    <div class="card-content grey lighten-3">
+        <span class="card-title grey-text text-darken-4">
+            {{ component.name }}
+        </span>
+    </div>
+    <div class="card-image">
+        <img src="/img/{{ component.image }}" height="150" alt="{{ component.image-alt }}" />
+    </div>
+    {% if component.documentation or component.examples %}
+    <div class="card-action">
+        {% if component.documentation %}
+        <a href="{{ component.documentation }}">
+            <i class="mdi-av-my-library-books"></i>
+            Documentation
+        </a>
+        {% endif %}
+        {% if component.examples %}
+        <a href="{{ component.examples }}">
+            <i class="mdi-action-explore"></i>
+            Examples
+        </a>
+        {% endif %}
+    </div>
+    {% endif %}
+</div>

--- a/_includes/platform-card.html
+++ b/_includes/platform-card.html
@@ -1,0 +1,34 @@
+<div class="card">
+    <div class="card-content grey lighten-3">
+        <span class="card-title grey-text text-darken-4">
+            {{ platform.name }}
+        </span>
+    </div>
+    <div class="card-image">
+        <img src="/img/{{ platform.image }}" height="200" />
+    </div>
+    <div class="card-action">
+        {% if platform.getting-started %}
+        <a href="{{ platform.getting-started }}">
+            Get started
+        </a>
+        {% else %}
+        <a href="">
+            Coming soon
+        </a>
+        {% endif %}
+
+        {% if platform.documentation %}
+        <a href="{{ platform.documentation }}">
+            <i class="mdi-av-my-library-books"></i>
+            Documentation
+        </a>
+        {% endif %}
+        {% if platform.examples %}
+        <a href="{{ platform.examples }}">
+            <i class="mdi-action-explore"></i>
+            Examples
+        </a>
+        {% endif %}
+    </div>
+</div>

--- a/components/index.html
+++ b/components/index.html
@@ -23,7 +23,7 @@ title: Supported Components
     {% endfor %}
 
     {% assign oddcount = site.data.components.size | modulo: 2 %}
-    {% if oddcount == 1 %}
+    {% if oddcount != 0 %}
     </div>
     {% endif %}
 </div>

--- a/components/index.html
+++ b/components/index.html
@@ -4,154 +4,26 @@ title: Supported Components
 ---
 
 <div class="container">
-
     <h2 class="white-text">{{ page.title }}</h2>
     <div class="divider"></div>
-    <br/>
+    <p></p>
 
+    {% for component in site.data.components %}
+    {% capture currentcycle %}{% cycle 'left', 'right' %}{% endcapture %}
+
+    {% if currentcycle == 'left' %}
     <div class="row">
-
+    {% endif %}
         <div class="col s12 m6">
-            <div class="card">
-                <div class="card-image">
-                    <img src="/img/grove/buzzer.svg" height="150" alt="Grove buzzer">
-                </div>
-                <div class="card-action grey lighten-3">
-                    <span class="card-title grey-text text-darken-4">Buzzer</span>
-                </div>
-            </div>
+            {% include component-card.html component=component %}
         </div>
-
-        <div class="col s12 m6">
-            <div class="card">
-                <div class="card-image">
-                    <img src="/img/grove/button.svg" height="150" alt="Grove button">
-                </div>
-                <div class="card-action grey lighten-3">
-                    <span class="card-title grey-text text-darken-4">Button</span>
-                </div>
-            </div>
-        </div>
-
+    {% if currentcycle == 'right' %}
     </div>
+    {% endif %}
+    {% endfor %}
 
-    <div class="row">
-
-        <div class="col s12 m6">
-            <div class="card">
-                <div class="card-image">
-                    <img src="/img/grove/light_sensor.svg" height="150" alt="Grove light sensor">
-                </div>
-                <div class="card-action grey lighten-3">
-                    <span class="card-title grey-text text-darken-4">Light Sensor</span>
-                </div>
-            </div>
-        </div>
-
-        <div class="col s12 m6">
-            <div class="card">
-                <div class="card-image">
-                    <img src="/img/grove/temperature_sensor.svg" height="150" alt="Grove temperature sensor">
-                </div>
-                <div class="card-action grey lighten-3">
-                    <span class="card-title grey-text text-darken-4">Temperature Sensor</span>
-                </div>
-            </div>
-        </div>
-
+    {% assign oddcount = site.data.components.size | modulo: 2 %}
+    {% if oddcount == 1 %}
     </div>
-
-    <div class="row">
-
-        <div class="col s12 m6">
-            <div class="card">
-                <div class="card-image">
-                    <img src="/img/grove/rotary_angle_sensor.svg" height="150" alt="Grove rotary angle sensor">
-                </div>
-                <div class="card-action grey lighten-3">
-                    <span class="card-title grey-text text-darken-4">Rotary Angle Sensor</span>
-                </div>
-            </div>
-        </div>
-
-        <div class="col s12 m6">
-            <div class="card">
-                <div class="card-image">
-                    <img src="/img/grove/sound_sensor.svg" height="150" alt="Grove sound sensor">
-                </div>
-                <div class="card-action grey lighten-3">
-                    <span class="card-title grey-text text-darken-4">Sound Sensor</span>
-                </div>
-            </div>
-        </div>
-
-    </div>
-
-    <div class="row">
-
-        <div class="col s12 m6">
-            <div class="card">
-                <div class="card-image">
-                    <img src="/img/grove/led.svg" height="150" alt="Grove LED">
-                </div>
-                <div class="card-action grey lighten-3">
-                    <span class="card-title grey-text text-darken-4">LED</span>
-                </div>
-            </div>
-        </div>
-
-        <div class="col s12 m6">
-            <div class="card">
-                <div class="card-image">
-                    <img src="/img/grove/relay.svg" height="150" alt="Grove relay">
-                </div>
-                <div class="card-action grey lighten-3">
-                    <span class="card-title grey-text text-darken-4">Smart Relay</span>
-                </div>
-            </div>
-        </div>
-
-    </div>
-
-    <div class="row">
-
-        <div class="col s12 m6">
-            <div class="card">
-                <div class="card-image">
-                    <img src="/img/grove/touch_sensor.svg" height="150" alt="Grove touch sensor">
-                </div>
-                <div class="card-action grey lighten-3">
-                    <span class="card-title grey-text text-darken-4">Touch Sensor</span>
-                </div>
-            </div>
-        </div>
-
-        <div class="col s12 m6">
-            <div class="card">
-                <div class="card-image">
-                    <img src="/img/grove/servo.svg" height="150" alt="Grove servo motor">
-                </div>
-                <div class="card-action grey lighten-3">
-                    <span class="card-title grey-text text-darken-4">Mini Servo</span>
-                </div>
-            </div>
-        </div>
-
-    </div>
-
-    <div class="row">
-
-        <div class="col s12 m6">
-            <div class="card">
-                <div class="card-image">
-                    <img src="/img/grove/lcd.svg" height="150" alt="Grove RGB LCD">
-                </div>
-                <div class="card-action grey lighten-3">
-                    <span class="card-title grey-text text-darken-4">RGB Backlight LCD</span>
-                </div>
-            </div>
-        </div>
-
-    </div>
-
+    {% endif %}
 </div>

--- a/platforms/index.html
+++ b/platforms/index.html
@@ -4,57 +4,26 @@ title: Supported Platforms
 ---
 
 <div class="container">
-
     <h2 class="white-text">{{ page.title }}</h2>
     <div class="divider"></div>
-    <br/>
+    <p></p>
 
+    {% for platform in site.data.platforms %}
+    {% capture currentcycle %}{% cycle 'left', 'right' %}{% endcapture %}
+
+    {% if currentcycle == 'left' %}
     <div class="row">
-
-        <div class="col s12 m4">
-            <div class="card">
-                <div class="card-image">
-                    <img src="/img/edison.svg" height=200 style="margin-top: 20px;"/>
-                </div>
-                <div class="card-content">
-                    <h4>Intel Edison</h4>
-                </div>
-                <div class="card-action grey lighten-3">
-                    <a href="/platforms/edison/" class="deep-orange-text">Start</a>
-                </div>
-            </div>
+    {% endif %}
+        <div class="col s12 m6">
+            {% include platform-card.html platform=platform %}
         </div>
-
-        <div class="col s12 m4">
-            <div class="card">
-                <div class="card-image">
-                    <img src="/img/raspberry_pi.svg" height=200 style="margin-top: 20px;"/>
-                </div>
-                <div class="card-content">
-                    <h4>Raspberry Pi</h4>
-                </div>
-                <div class="card-action grey lighten-3">
-                    <!--a href="#">Start</a-->
-                    <a href="#" class="deep-orange-text">Coming Soon!</a>
-                </div>
-            </div>
-        </div>
-
-        <div class="col s12 m4">
-            <div class="card">
-                <div class="card-image">
-                    <img src="/img/arduino_uno.svg" height=200 style="margin-top: 20px;"/>
-                </div>
-                <div class="card-content">
-                    <h4>Arduino</h4>
-                </div>
-                <div class="card-action grey lighten-3">
-                    <!--a href="#">Start</a-->
-                    <a href="#" class="deep-orange-text">Coming Soon!</a>
-                </div>
-            </div>
-        </div>
-
+    {% if currentcycle == 'right' %}
     </div>
+    {% endif %}
+    {% endfor %}
 
+    {% assign oddcount = site.data.platforms.size | modulo: 2 %}
+    {% if oddcount != 0 %}
+    </div>
+    {% endif %}
 </div>


### PR DESCRIPTION
Right now both the platforms and components pages are manually built out by copy/pasting the previous template and adding in the information. This isn't the greatest and scales poorly, so I've created includes for components and platforms. This means that adding a new component or platform is as simple as editing the data file (YAML) and adding the necessary fields.

I've also redesigned the platforms cards to give a bit more information: [Before](https://i.imgur.com/bjOZfMB.png) and [after](https://i.imgur.com/mLl4DAv.png)

And the components cards to include some links: [Before](https://i.imgur.com/KNmZbuQ.png) and [after](https://i.imgur.com/l3ufXUD.png)
